### PR TITLE
수정 및 추가: ImgaeField 활용 위한 Pillow 패키지 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,10 @@ Django==4.0.3
 django-storages==1.12.3
 jmespath==0.10.0
 mysqlclient==2.1.0
+Pillow==9.0.1
 python-dateutil==2.8.2
 s3transfer==0.5.2
 six==1.16.0
 sqlparse==0.4.2
+tzdata==2021.5
 urllib3==1.26.8


### PR DESCRIPTION
프로필 사진 등록 및 게시글 사진 등록 시 이미지 파일 업로드가 필요합니다. 이를 위해 ImageField를 사용하려고 하는데, 관련 패지키인 Pillow를 설치하고 requirements에 추가했습니다. 확인해 주세요!