### PR TITLE
수정: static 리소스 저장 및 로드 경로 aws로 변경 위한 코드 수정

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -153,12 +153,13 @@ POST_MEDIA_URL = '/post_upload_images/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # AWS S3설정 - 개발 단계  주석처리
-# DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-# STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+AWS_S3_SECURE_URLS = True
 
-# AWS_S3_REGION_NAME = 'ap-northeast-2'
-# AWS_S3_SIGNATURE_VERSION = 's3v4'
-# AWS_ACCESS_KEY_ID = MY_AWS['ACCESS_KEY_ID']
-# AWS_SECRET_ACCESS_KEY = MY_AWS['SECRET_ACCESS_KEY']
-# AWS_STORAGE_BUCKET_NAME = MY_AWS['STORAGE_BUCKET_NAME']
-# AWS_DEFAULT_ACL = 'public-read'
+AWS_S3_REGION_NAME = 'ap-northeast-2'
+AWS_S3_SIGNATURE_VERSION = 's3v4'
+AWS_ACCESS_KEY_ID = MY_AWS['ACCESS_KEY_ID']
+AWS_SECRET_ACCESS_KEY = MY_AWS['SECRET_ACCESS_KEY']
+AWS_STORAGE_BUCKET_NAME = MY_AWS['STORAGE_BUCKET_NAME']
+AWS_DEFAULT_ACL = 'public-read'

--- a/post/post_models.py
+++ b/post/post_models.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from django.db import models
 
+from mountain.models import Mountain
 from user.user_models import MooyahoUser
 
 
@@ -37,11 +38,11 @@ class Post(models.Model):
                              db_column='author_id', on_delete=models.CASCADE, default='')
     title = models.CharField(max_length=20, null=False)
     mountain_name = models.CharField(max_length=20, null=False, default='')
+    # Mountain모델을 참조하기 위한 외래키(참조되는 모델, Mountain에서 Post 역참조 시 'post_set' 대체명, 컬럼명)
+    mountain = models.ForeignKey(Mountain, related_name='post_mt_ref', on_delete=models.CASCADE)
     content = models.TextField(null=False)
     rating = models.CharField(max_length=10, null=False)
-    # hiking_img = models.ImageField(null=False, blank=False, upload_to=hiking_img_upload_path)
-    hiking_img = models.ImageField(null=False, blank=False,
-                                   upload_to='post/post_upload_images/')
+    hiking_img = models.ImageField(null=False, blank=False)
     deleted = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/post/urls.py
+++ b/post/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('posts/<int:pk>/', post_service.post_detail, name='posts-detail'),
     path('posts/new/', post_service.post, name='posts-new'),
     path('posts/<int:pk>/comments/', comment_service.comment, name='comment'),
-] + static(settings.POST_MEDIA_URL, document_root=settings.POST_MEDIA_ROOT)
+]
+# + static(settings.POST_MEDIA_URL, document_root=settings.POST_MEDIA_ROOT)

--- a/user/urls.py
+++ b/user/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('signup/', user_service.signup, name='signup'),
     path('logout/', user_service.logout, name='logout'),
     path('mypage/', user_service.my_page, name='mypage'),
-] + static(settings.USER_MEDIA_URL, document_root=settings.USER_MEDIA_ROOT)
+]
+# + static(settings.USER_MEDIA_URL, document_root=settings.USER_MEDIA_ROOT)


### PR DESCRIPTION
1. Post모델에서 등산 사진 업로드 경로 옵션을 수정했습니다.
2. User, Post의 static 리소스를 aws에서 사용하기 위해 url에서 static 경로 코드를 주석 처리 했습니다.
3. settings파일에 aws 관련 코드 주석 처리를 해제했습니다.